### PR TITLE
add new firefox profiling output

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,60 @@ go tool pprof -http :8000 http://localhost:8080/debug/pprof/profile?seconds=30
 
 ![image](https://user-images.githubusercontent.com/2567525/214325045-0907e055-8f17-45cf-9f57-c2b52c366854.png)
 
-## Firefox profiling
+## Firefox Profiler
+
+### Basic example with `curl`
+
+1- Execute the profiler for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the response to `profiling_results/firefox-profiler-example.json.gz`
+
+```shell
+curl -s "http://localhost:8080/profiler/profile?event=cpu&output=fp&duration=60" -o profiling_results/firefox-profiler-example.json.gz
+```
+
+2- Visit the [Firefox Profiler page](https://profiler.firefox.com)
+
+![image](docs/firefox-profiler/fp-welcome-page.png)
+
+3- Load the output file from `step 1`, and you'll see the profiling result
+
+- Call tree
+
+![image](docs/firefox-profiler/fp-call-tree.png)
+
+- Flame graph
+
+![image](docs/firefox-profiler/fp-flame-graph.png)
+
+### Example using [jfrtofp-server](https://github.com/parttimenerd/jfrtofp-server)
+
+1- Execute the profiler for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the response to `profiling_results/firefox-profiler-example.json.gz`
+
+```shell
+curl -s "http://localhost:8080/profiler/profile?event=cpu&output=fp&duration=60" -o profiling_results/firefox-profiler-example.json.gz
+```
+
+** Note ** there is no need to ask for the `fp`(Firefox Profiler) output, you can provide `jfr` as output and the `jfrtofp-server` will do the conversion.
+
+2- Start the `jfrtofp-server`, you can follow the steps from the [README](https://github.com/parttimenerd/jfrtofp-server#jfrtofp-server), with the output file from `step 1` as an argument
+```shell
+java -jar jfrtofp-server-all.jar profiling_results/firefox-profiler-example.json.gz
+```
+
+3- The `jfrtofp-server` will log a message like `Navigate to http://localhost:55287/from-url/http%3A%2F%2Flocalhost%3A55287%2Ffiles%firefox-profiler-example.json.gz to launch the profiler view`
+
+4- Just click that link, and you will see the profiling result in the `Firefox Profiler` page
+
+- Call tree
+
+![image](docs/firefox-profiler/fp-call-tree.png)
+
+- Flame graph
+
+![image](docs/firefox-profiler/fp-flame-graph.png)
+
+### Example using the `loop.sh` script
+
+1- Continuously profile the application for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the execution results to `profiling_results/` folder
 
 ```shell
 ./loop.sh cpu 60 profiling_results fp
@@ -77,9 +130,19 @@ Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04
 Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04:18:24 took 60 seconds.
 ```
 
-Then go to [firefox profiler](https://profiler.firefox.com) and load your file.
+2- Visit the [Firefox Profiler page](https://profiler.firefox.com)
 
+![image](docs/firefox-profiler/fp-welcome-page.png)
 
+3- Load the output file from `step 1`, and you'll see the profiling result
+
+- Call tree
+
+![image](docs/firefox-profiler/fp-call-tree.png)
+
+- Flame graph
+
+![image](docs/firefox-profiler/fp-flame-graph.png)
 
 ## TODO
 - [x] Release to Maven Central

--- a/README.md
+++ b/README.md
@@ -70,58 +70,56 @@ go tool pprof -http :8000 http://localhost:8080/debug/pprof/profile?seconds=30
 
 ## Firefox Profiler
 
-### Basic example with `curl`
+### Profiling results
 
-1- Execute the profiler for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the response to `profiling_results/firefox-profiler-example.json.gz`
+#### Call tree
 
-```shell
-curl -s "http://localhost:8080/profiler/profile?event=cpu&output=fp&duration=60" -o profiling_results/firefox-profiler-example.json.gz
-```
+![image](https://user-images.githubusercontent.com/18125567/216783099-e7e25bb4-8805-4e65-b746-7ebd86fa4eb9.png)
 
-2- Visit the [Firefox Profiler page](https://profiler.firefox.com)
+#### Flame graph
 
-![image](docs/firefox-profiler/fp-welcome-page.png)
+![image](https://user-images.githubusercontent.com/18125567/216783114-3e0a101d-def9-4d1f-a37a-a9c8fa4c0c2b.png)
 
-3- Load the output file from `step 1`, and you'll see the profiling result
+### Examples
 
-- Call tree
+1. [Basic example with `curl`](#basic-example-with-curl)
+2. [Example using `jfrtofp-server`](#example-using-jfrtofp-server)
+3. [Example using the `loop.sh` script](#example-using-the-loopsh-script)
 
-![image](docs/firefox-profiler/fp-call-tree.png)
+#### Basic example with `curl`
 
-- Flame graph
-
-![image](docs/firefox-profiler/fp-flame-graph.png)
-
-### Example using [jfrtofp-server](https://github.com/parttimenerd/jfrtofp-server)
-
-1- Execute the profiler for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the response to `profiling_results/firefox-profiler-example.json.gz`
+1. Execute the profiler for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the response to `profiling_results/firefox-profiler-example.json.gz`
 
 ```shell
 curl -s "http://localhost:8080/profiler/profile?event=cpu&output=fp&duration=60" -o profiling_results/firefox-profiler-example.json.gz
 ```
 
-** Note ** there is no need to ask for the `fp`(Firefox Profiler) output, you can provide `jfr` as output and the `jfrtofp-server` will do the conversion.
+2. Visit the [Firefox Profiler page](https://profiler.firefox.com)
 
-2- Start the `jfrtofp-server`, you can follow the steps from the [README](https://github.com/parttimenerd/jfrtofp-server#jfrtofp-server), with the output file from `step 1` as an argument
+![image](https://user-images.githubusercontent.com/18125567/216783063-4b7ce195-e717-45a7-b6a4-5cb30bf67b9e.png)
+
+3. Load the output file from `step 1`, and you'll see the profiling result
+
+#### Example using `jfrtofp-server`
+
+1. Execute the profiler for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the response to `profiling_results/firefox-profiler-example.json.gz`
+
+```shell
+curl -s "http://localhost:8080/profiler/profile?event=cpu&output=fp&duration=60" -o profiling_results/firefox-profiler-example.json.gz
+```
+
+2. Start the [jfrtofp-server](https://github.com/parttimenerd/jfrtofp-server), you can follow the steps from the [README](https://github.com/parttimenerd/jfrtofp-server#jfrtofp-server), with the output file from `step 1` as an argument
 ```shell
 java -jar jfrtofp-server-all.jar profiling_results/firefox-profiler-example.json.gz
 ```
 
-3- The `jfrtofp-server` will log a message like `Navigate to http://localhost:55287/from-url/http%3A%2F%2Flocalhost%3A55287%2Ffiles%firefox-profiler-example.json.gz to launch the profiler view`
+3. The [jfrtofp-server](https://github.com/parttimenerd/jfrtofp-server) will log a message like `Navigate to http://localhost:55287/from-url/http%3A%2F%2Flocalhost%3A55287%2Ffiles%firefox-profiler-example.json.gz to launch the profiler view`
 
-4- Just click that link, and you will see the profiling result in the `Firefox Profiler` page
+4. Just click that link, and you will see the profiling result in the `Firefox Profiler` page
 
-- Call tree
+#### Example using the `loop.sh` script
 
-![image](docs/firefox-profiler/fp-call-tree.png)
-
-- Flame graph
-
-![image](docs/firefox-profiler/fp-flame-graph.png)
-
-### Example using the `loop.sh` script
-
-1- Continuously profile the application for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the execution results to `profiling_results/` folder
+1. Continuously profile the application for the `cpu` event, `fp` (Firefox Profiler) output, a `60 seconds` duration and write the execution results to `profiling_results/` folder
 
 ```shell
 ./loop.sh cpu 60 profiling_results fp
@@ -130,19 +128,12 @@ Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04
 Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04:18:24 took 60 seconds.
 ```
 
-2- Visit the [Firefox Profiler page](https://profiler.firefox.com)
+2. Visit the [Firefox Profiler page](https://profiler.firefox.com)
 
-![image](docs/firefox-profiler/fp-welcome-page.png)
+![image](https://user-images.githubusercontent.com/18125567/216783063-4b7ce195-e717-45a7-b6a4-5cb30bf67b9e.png)
 
-3- Load the output file from `step 1`, and you'll see the profiling result
+3. Load the output file from `step 1`, and you'll see the profiling result
 
-- Call tree
-
-![image](docs/firefox-profiler/fp-call-tree.png)
-
-- Flame graph
-
-![image](docs/firefox-profiler/fp-flame-graph.png)
 
 ## TODO
 - [x] Release to Maven Central

--- a/README.md
+++ b/README.md
@@ -70,15 +70,8 @@ go tool pprof -http :8000 http://localhost:8080/debug/pprof/profile?seconds=30
 
 ## Firefox Profiler
 
-### Profiling results
-
-#### Call tree
-
-![image](https://user-images.githubusercontent.com/18125567/216783099-e7e25bb4-8805-4e65-b746-7ebd86fa4eb9.png)
-
-#### Flame graph
-
-![image](https://user-images.githubusercontent.com/18125567/216783114-3e0a101d-def9-4d1f-a37a-a9c8fa4c0c2b.png)
+1. [Examples](#examples)
+2. [Profiling results](#profiling-results)
 
 ### Examples
 
@@ -134,6 +127,15 @@ Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04
 
 3. Load the output file from `step 1`, and you'll see the profiling result
 
+### Profiling results
+
+#### Call tree
+
+![image](https://user-images.githubusercontent.com/18125567/216783099-e7e25bb4-8805-4e65-b746-7ebd86fa4eb9.png)
+
+#### Flame graph
+
+![image](https://user-images.githubusercontent.com/18125567/216783114-3e0a101d-def9-4d1f-a37a-a9c8fa4c0c2b.png)
 
 ## TODO
 - [x] Release to Maven Central

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ go tool pprof -http :8000 http://localhost:8080/debug/pprof/profile?seconds=30
 
 ![image](https://user-images.githubusercontent.com/2567525/214325045-0907e055-8f17-45cf-9f57-c2b52c366854.png)
 
+## Firefox profiling
+
+```shell
+./loop.sh cpu 60 profiling_results fp
+
+Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04:17:24 took 60 seconds.
+Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04:18:24 took 60 seconds.
+```
+
+Then go to [firefox profiler](https://profiler.firefox.com) and load your file.
+
+
 
 ## TODO
 - [x] Release to Maven Central

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ curl -s "http://localhost:8080/profiler/profile?event=cpu&output=fp&duration=60"
 
 2. Visit the [Firefox Profiler page](https://profiler.firefox.com)
 
-![image](https://user-images.githubusercontent.com/18125567/216783063-4b7ce195-e717-45a7-b6a4-5cb30bf67b9e.png)
+![Screenshot 2023-02-04 at 13 12 49](https://user-images.githubusercontent.com/18125567/216790473-2749c404-5b1b-41c8-bb3c-fc3854e60f1b.png)
 
 3. Load the output file from `step 1`, and you'll see the profiling result
 
@@ -123,7 +123,7 @@ Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04
 
 2. Visit the [Firefox Profiler page](https://profiler.firefox.com)
 
-![image](https://user-images.githubusercontent.com/18125567/216783063-4b7ce195-e717-45a7-b6a4-5cb30bf67b9e.png)
+![Screenshot 2023-02-04 at 13 12 49](https://user-images.githubusercontent.com/18125567/216790425-2a888508-0582-4f6e-a9de-2a6ef4a8c13e.png)
 
 3. Load the output file from `step 1`, and you'll see the profiling result
 
@@ -131,11 +131,11 @@ Profile saved to profiling_results/cpu_profile_2023-01-24_16-16-24.json.gz at 04
 
 #### Call tree
 
-![image](https://user-images.githubusercontent.com/18125567/216783099-e7e25bb4-8805-4e65-b746-7ebd86fa4eb9.png)
+![Screenshot 2023-02-04 at 13 24 53](https://user-images.githubusercontent.com/18125567/216790459-c7dc601e-c44b-4763-aca7-bf268dfc243f.png)
 
 #### Flame graph
 
-![image](https://user-images.githubusercontent.com/18125567/216783114-3e0a101d-def9-4d1f-a37a-a9c8fa4c0c2b.png)
+![Screenshot 2023-02-04 at 13 27 32](https://user-images.githubusercontent.com/18125567/216790464-3f0437c5-4a49-46c2-9709-8f7ed3ccf5fb.png)
 
 ## TODO
 - [x] Release to Maven Central

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,21 @@
         <io.vavr.version>0.10.3</io.vavr.version>
         <com.typesafe.config.version>1.4.2</com.typesafe.config.version>
         <org.tinylog.version>2.5.0</org.tinylog.version>
+        <me.bechberger.version>0.0.2-SNAPSHOT</me.bechberger.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>oss-snapshots</id>
+            <name>Oss Snapshots</name>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>maven-central</id>
+            <name>Maven central</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -40,6 +54,11 @@
             <groupId>org.tinylog</groupId>
             <artifactId>tinylog-impl</artifactId>
             <version>${org.tinylog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>me.bechberger</groupId>
+            <artifactId>jfrtofp</artifactId>
+            <version>${me.bechberger.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -72,19 +91,21 @@
                         </goals>
                         <configuration>
                             <artifactSet>
-                               <excludes>
-                                   <exclude>org.codehaus.mojo</exclude>
+                                <excludes>
+                                    <exclude>org.codehaus.mojo</exclude>
                                 </excludes>
                             </artifactSet>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Premain-Class>io.github.dpsoft.ap.Agent</Premain-Class>
                                         <Agent-Class>io.github.dpsoft.ap.Agent</Agent-Class>
                                     </manifestEntries>
                                 </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>
@@ -117,6 +138,10 @@
                                 <relocation>
                                     <pattern>dev.dirs</pattern>
                                     <shadedPattern>dpsoft.ap.libs.dev.dirs</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>me.bechberger</pattern>
+                                    <shadedPattern>dpsoft.ap.libs.me.bechberger</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/scripts/loop.sh
+++ b/scripts/loop.sh
@@ -2,14 +2,20 @@
 event=${1:-itimer}
 profiling_duration=${2:-30}
 results_folder=${3:-profiling_results}
+output=${4:-flame}
 
 mkdir -p $results_folder
 
 while true; do
     timestamp=$(date +%Y-%m-%d_%H-%M-%S)
-    output_file="${event}_profile_$timestamp.html"
+    if [[ $output == "fp" ]]
+    then
+        output_file="${event}_profile_$timestamp.json.gz"
+    else
+        output_file="${event}_profile_$timestamp.html"
+    fi
     start_time=$(date +%s)
-    curl -s "http://localhost:8080/profiler/profile?event=$event&output=flame&duration=$profiling_duration" -o "$results_folder/$output_file"
+    curl -s "http://localhost:8080/profiler/profile?event=$event&output=$output&duration=$profiling_duration" -o "$results_folder/$output_file"
     end_time=$(date +%s)
     duration=$((end_time - start_time))
     echo "Profile saved to $results_folder/$output_file at $(date) took $duration seconds."

--- a/src/main/java/io/github/dpsoft/ap/ProfilerExecutor.java
+++ b/src/main/java/io/github/dpsoft/ap/ProfilerExecutor.java
@@ -15,10 +15,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Paths;
 import java.util.zip.GZIPOutputStream;
 
 import static io.vavr.API.*;
 import static io.vavr.Predicates.*;
+
+import me.bechberger.jfrtofp.processor.SimpleProcessor;
+import me.bechberger.jfrtofp.processor.Config;
 
 public class ProfilerExecutor {
 
@@ -49,11 +53,12 @@ public class ProfilerExecutor {
 
     public void pipeTo(OutputStream out, String output) {
         final var result = Match(output).of(
-                Case($(is("pprof")), () -> toPProf(out)),
-                Case($(is("jfr")), () ->  toJFR(out)),
-                Case($(is("nflx")), () ->  toFlameScope(out)),
-                Case($(isIn("flamegraph", "flame", "collapsed", "hotcold")),(type) -> toFlame(type, out)),
-                Case($(isNull()), () -> toJFR(out)));
+            Case($(is("pprof")), () -> toPProf(out)),
+            Case($(is("jfr")), () -> toJFR(out)),
+            Case($(is("nflx")), () -> toFlameScope(out)),
+            Case($(isIn("flamegraph", "flame", "collapsed", "hotcold")), (type) -> toFlame(type, out)),
+            Case($(isIn("fp")), () -> toFirefoxProfiler(out)),
+            Case($(isNull()), () -> toJFR(out)));
 
         result.andFinally(file::delete);
         result.onFailure(cause -> Logger.error(cause, "It has not been possible to pipe the profiler result to the output stream."));
@@ -63,6 +68,15 @@ public class ProfilerExecutor {
         return Try.run(() -> {
             try (var fileReader = new FileInputStream(file.getAbsolutePath()); var outputStream = new GZIPOutputStream(out)) {
                 fileReader.transferTo(outputStream);
+            }
+        });
+    }
+
+    private Try<Void> toFirefoxProfiler(OutputStream out) {
+        return Try.run(() -> {
+            final var processor = new SimpleProcessor(new Config(), Paths.get(file.getAbsolutePath()));
+            try (var outputStream = new PrintStream(out)) {
+                processor.processZipped(outputStream);
             }
         });
     }

--- a/src/main/java/io/github/dpsoft/ap/handler/AsyncProfilerHandler.java
+++ b/src/main/java/io/github/dpsoft/ap/handler/AsyncProfilerHandler.java
@@ -32,10 +32,10 @@ public class AsyncProfilerHandler implements HttpHandler {
             exchange.getRequestBody().close();
             exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0);
 
-            if(configuration.isGoMode()) exchange.getResponseHeaders().set("Content-Encoding", "gzip");
-
             final var queryParamsMap = Functions.splitQueryParams(exchange.getRequestURI());
             final var command = Command.from(queryParamsMap, configuration);
+
+            if(configuration.isGoMode() || "fp".equals(command.output)) exchange.getResponseHeaders().set("Content-Encoding", "gzip");
 
             ProfilerExecutor
                     .with(asyncProfiler, configuration)


### PR DESCRIPTION
Very simple first approach to enable firefox profiling using https://github.com/parttimenerd/jfrtofp, we are using just the default configurations from the library (it's not customizable), in the future it'd be nice to customize these configurations and use the https://github.com/parttimenerd/jfrtofp-server

I'm not sure if the Command.output should take the value "fp", in this case it'd be nice to change that field type to an enum instead of a string, or if we should have a firefox profiler mode in the configuration 🤔 

Solves #6 